### PR TITLE
Bump mdtraj version from 1.9.6 to 1.9.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ repository = 'https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR'
 parsing = [
     'asr==0.4.1',
     'netCDF4==1.5.4',
-    'mdtraj==1.9.6',
+    'mdtraj==1.9.9',
     'h5py==3.6.0',
     'pyzeo==0.1.4',
     'quippy-ase==0.9.14'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -150,7 +150,7 @@ matplotlib-inline==0.1.6  # via -r requirements.txt, ipykernel, ipython
 matplotlib-scalebar==0.8.1  # via -r requirements.txt, orix
 mccabe==0.6.1             # via pylint
 mdanalysis==2.5.0         # via -r requirements.txt, nomad-lab (pyproject.toml)
-mdtraj==1.9.6             # via -r requirements.txt, nomad-lab (pyproject.toml)
+mdtraj==1.9.9             # via -r requirements.txt, nomad-lab (pyproject.toml)
 memoization==0.4.0        # via -r requirements.txt, nomad-lab (pyproject.toml)
 mergedeep==1.3.4          # via mkdocs
 mistune==2.0.4            # via -r requirements.txt, m2r

--- a/requirements.txt
+++ b/requirements.txt
@@ -130,7 +130,7 @@ matplotlib==3.5.3         # via ase, asr, diffsims, hyperspy, kikuchipy, matplot
 matplotlib-inline==0.1.6  # via ipykernel, ipython
 matplotlib-scalebar==0.8.1  # via orix
 mdanalysis==2.5.0         # via atomisticparsers (dependencies/parsers/atomistic/pyproject.toml), nomad-lab (pyproject.toml)
-mdtraj==1.9.6             # via nomad-lab (pyproject.toml)
+mdtraj==1.9.9             # via nomad-lab (pyproject.toml)
 memoization==0.4.0        # via nomad-lab (pyproject.toml)
 mistune==2.0.4            # via m2r
 mmtf-python==1.1.3        # via mdanalysis


### PR DESCRIPTION
An extension of https://github.com/nomad-coe/nomad/issues/81.  Running the dev env script, this time on the `develop` branch, was still giving a Cython-based compilation problem that isn't interesting but I've attached if anyone wants to see it.  It looks like the problem was solved in https://github.com/mdtraj/mdtraj/pull/1801.

`setup_dev_env.sh` works after this, but I haven't run the tests.

[mdtraj_compilation_error.txt](https://github.com/nomad-coe/nomad/files/12516794/mdtraj_compilation_error.txt)
