### PR TITLE
Update outdated documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-See also the more detailed [contributing guide](https://nomad-lab.eu/docs/develop/contrib.html) in the documentation.
+See also the more detailed [contributing guide](https://nomad-lab.eu/prod/v1/docs/howto/develop/contrib.html) in the documentation.
 
 We maintain two git repositories that you can contribute to. The default choice for
 external contributors should be the [GitHub project](https://github.com/FAIRmat-NFDI/nomad)

--- a/gui/src/components/uploads/UploadOverview.js
+++ b/gui/src/components/uploads/UploadOverview.js
@@ -302,7 +302,7 @@ SupportedCodes.propTypes = {
 }
 
 export function UploadDocumentation({ children }) {
-  return <Link href={`${appBase}/docs/web.html#uploading-and-publishing-data`}>
+  return <Link href={`${appBase}/docs/howto/manage/gui/upload.html`}>
     {children}
   </Link>
 }
@@ -311,7 +311,7 @@ UploadDocumentation.propTypes = {
 }
 
 export function SchemaDocumentation({ children }) {
-  return <Link href={`${appBase}/docs/schema/basics.html`}>
+  return <Link href={`${appBase}/docs/explanation/basics.html`}>
     {children}
   </Link>
 }


### PR DESCRIPTION
## Summary

Update outdated documentation links to the current documentation pages.

### Changes

- Update the upload documentation link in the GUI.
- Update the schema documentation link in the GUI.
- Update the contributing guide link in `CONTRIBUTING.md`.


**Note:** I also noticed that `README.md` contains an older documentation URL that currently redirects correctly (line 23). I left it unchanged since it is not broken.